### PR TITLE
Bind libsnark sha256

### DIFF
--- a/lib/sha256_ethereum.hpp
+++ b/lib/sha256_ethereum.hpp
@@ -19,8 +19,6 @@ using namespace libff;
 
 using std::vector;
 
-//typedef libff::Fr<libff::default_ec_pp> FieldT;
-
 typedef libff::Fr<alt_bn128_pp> FieldT;
 
 class sha256_ethereum : gadget<FieldT> {

--- a/lib/sha256_ethereum.hpp
+++ b/lib/sha256_ethereum.hpp
@@ -19,7 +19,9 @@ using namespace libff;
 
 using std::vector;
 
-typedef libff::Fr<libff::default_ec_pp> FieldT;
+//typedef libff::Fr<libff::default_ec_pp> FieldT;
+
+typedef libff::Fr<alt_bn128_pp> FieldT;
 
 class sha256_ethereum : gadget<FieldT> {
 private:

--- a/lib/wraplibsnarkgadgets.cpp
+++ b/lib/wraplibsnarkgadgets.cpp
@@ -60,6 +60,7 @@ std::string r1cs_to_json(protoboard<FieldT> pb)
 
 char* _sha256Constraints()
 {
+    libff::alt_bn128_pp::init_public_params();
     protoboard<FieldT> pb;
     block_variable<FieldT> input(pb, 256, "input");
     digest_variable<FieldT> output(pb, 256, "output");
@@ -75,6 +76,9 @@ char* _sha256Constraints()
 
 std::string array_to_json(protoboard<FieldT> pb)
 {
+
+
+
     std::stringstream ss;
     r1cs_variable_assignment<FieldT> values = pb.full_variable_assignment();
     ss << "\n{\"TestVariables\":[";

--- a/lib/wraplibsnarkgadgets.cpp
+++ b/lib/wraplibsnarkgadgets.cpp
@@ -76,9 +76,6 @@ char* _sha256Constraints()
 
 std::string array_to_json(protoboard<FieldT> pb)
 {
-
-
-
     std::stringstream ss;
     r1cs_variable_assignment<FieldT> values = pb.full_variable_assignment();
     ss << "\n{\"TestVariables\":[";


### PR DESCRIPTION
There is an issue with template initialization that caused the constraint system to contain only zeros. 

This pr fixes that. 

@xwvvvvwx If you have time, could you take a look and perhaps change the `libff::alt_bn128_pp::init_public_params();` to a more "cpp" place? 
