### PR TITLE
scripts: ensure one-liner install script works with FreeBSD

### DIFF
--- a/scripts/one_liner.sh
+++ b/scripts/one_liner.sh
@@ -297,7 +297,7 @@ main() {
     say_err "Fetching: $url"
 
     td=$(mktemp -d || mktemp -d -t tmp)
-    curl -sLf --show-error $url | tar -C $td -xz
+    curl -sLf --show-error $url | tar -C $td -xzf -
 
     # install ZoKrates
     for f in $(ls $td); do


### PR DESCRIPTION
FreeBSD's `tar` requires explicit naming of the input file, and `-` if this is the standard input.